### PR TITLE
メイン画面に3つの紙芝居画面を実装

### DIFF
--- a/lib/EmptyAppBar.dart
+++ b/lib/EmptyAppBar.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+/// 空のアプリバー
+class EmptyAppBar extends StatelessWidget implements PreferredSizeWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.transparent,
+    );
+  }
+
+  @override
+  Size get preferredSize => Size(0.0, 0.0);
+}

--- a/lib/login.dart
+++ b/lib/login.dart
@@ -69,7 +69,7 @@ class _LoginState extends State<Login> {
                 onPressed: () {
                   Navigator.push(
                     context,
-                    MaterialPageRoute(builder: (context) => const Main()),
+                    MaterialPageRoute(builder: (context) => Main()),
                   );
                 },
                 child: const Text('ログイン'),

--- a/lib/main_page.dart
+++ b/lib/main_page.dart
@@ -1,25 +1,75 @@
 import 'package:flutter/material.dart';
+import 'package:teamc/page1.dart';
+import 'package:teamc/page2.dart';
+import 'package:teamc/page3.dart';
 
+import 'EmptyAppBar.dart';
+
+// メイン画面
 class Main extends StatefulWidget {
-  const Main({Key? key}) : super(key: key);
+  Main() : super();
 
   @override
-  State<Main> createState() => _MainState();
+  _MainState createState() => _MainState();
 }
 
 class _MainState extends State<Main> {
 
+  // 選択中のボトムバーの値
+  int currentTabIndex = 0;
+
+  // タップした際の挙動
+  onTapped(int index) {
+    setState(() => currentTabIndex = index);
+  }
+
+  // 表示するページ一覧
+  List<Widget> pages = [
+    page1(),
+    page2(),
+    page3(),
+  ];
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        body: GestureDetector(
-      onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
-      behavior: HitTestBehavior.opaque,
-      child: Container(
-        color: Colors.red,
-        child: Text('メイン画面', style: TextStyle(
-            fontSize: 60.0, fontWeight: FontWeight.bold),),
+    // ボトムバー
+    List<BottomNavigationBarItem> bottomBars = [
+      const BottomNavigationBarItem(
+        icon: Icon(Icons.settings),
+        label: '111',
       ),
-    ));
+      const BottomNavigationBarItem(
+        icon: Icon(Icons.settings),
+        label: '222',
+      ),
+      const BottomNavigationBarItem(
+        icon: Icon(Icons.settings),
+        label: '333',
+      )
+    ];
+
+    return Scaffold(
+        appBar: EmptyAppBar(),
+        body: IndexedStack(
+          index: currentTabIndex,
+          children: pages,
+        ),
+        floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+        floatingActionButton: FloatingActionButton(
+            backgroundColor: Colors.blue,
+            onPressed: () {
+              // TODO 投稿画面に画面遷移させる
+            },
+            child: const Icon(Icons.send)
+            // Icon(Icons.add),
+            ),
+        bottomNavigationBar: BottomNavigationBar(
+            onTap: (int index) {
+              if (index != 1) {
+                onTapped(index);
+              }
+            },
+            currentIndex: currentTabIndex,
+            items: bottomBars));
   }
 }

--- a/lib/page1.dart
+++ b/lib/page1.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// テストページ
+class page1 extends StatefulWidget {
+  @override
+  _StationInformationPageState createState() => _StationInformationPageState();
+}
+
+class _StationInformationPageState extends State<page1> {
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+        child: Container(
+      color: Colors.red,
+    ));
+  }
+}

--- a/lib/page2.dart
+++ b/lib/page2.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// テストページ
+class page2 extends StatefulWidget {
+  @override
+  _StationInformationPageState createState() => _StationInformationPageState();
+}
+
+class _StationInformationPageState extends State<page2> {
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+        child: Container(
+      color: Colors.green,
+    ));
+  }
+}

--- a/lib/page3.dart
+++ b/lib/page3.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// テストページ
+class page3 extends StatefulWidget {
+  @override
+  _StationInformationPageState createState() => _StationInformationPageState();
+}
+
+class _StationInformationPageState extends State<page3> {
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+        child: Container(
+      color: Colors.blue,
+    ));
+  }
+}


### PR DESCRIPTION
○実装したこと
　ログインボタン押下後に3つのボトムバーを表示する画面に遷移するように実装

<img width="432" alt="スクリーンショット 2023-09-30 21 25 07" src="https://github.com/tomoki1590/aoharu/assets/19570256/6f40af2c-263a-4670-ae80-083a56a819a1">

　
　

